### PR TITLE
[ AMSD-24 ] Add migration support using Liquibase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=airport-management-system
+
+spring.datasource.url=jdbc:mysql://localhost:3306/ams_db
+spring.datasource.username=amsadmin
+spring.datasource.password=amsadmin
+
+spring.liquibase.change-log=classpath:/db/changelog/app-changelog.xml
+spring.liquibase.default-schema=ams_db

--- a/src/main/resources/db/changelog/app-changelog.xml
+++ b/src/main/resources/db/changelog/app-changelog.xml
@@ -1,0 +1,10 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+http://www.liquibase.org/xml/ns/dbchangelog
+https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+
+</databaseChangeLog>


### PR DESCRIPTION
The Liquibase dependency was added to the project, and the necessary configuration was performed via files. The database connection was made using the properties provided by MySQL and JPA.